### PR TITLE
patch: KA-9676 set timeout on retrieveResponse channel to handle broken connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,6 +22,7 @@ package grammes
 
 import (
 	"sync"
+	"time"
 
 	"github.com/Kaleidoscope-Inc/grammes/gremconnect"
 	"github.com/Kaleidoscope-Inc/grammes/gremerror"
@@ -60,6 +61,8 @@ type Client struct {
 	broken bool
 	// logger is used to log out debug statements and errors from the client.
 	logger logging.Logger
+	// ResponseTimeout is the timeout for waiting for Gremlin responses.
+	ResponseTimeout time.Duration
 }
 
 // setupClient default values some fields in the client.

--- a/configuration.go
+++ b/configuration.go
@@ -102,3 +102,10 @@ func WithReadingWait(interval time.Duration) ClientConfiguration {
 		c.conn.SetReadingWait(interval)
 	}
 }
+
+// WithResponseTimeout sets the timeout for waiting for Gremlin responses.
+func WithResponseTimeout(timeout time.Duration) ClientConfiguration {
+	return func(c *Client) {
+		c.ResponseTimeout = timeout
+	}
+}

--- a/gremconnect/dialer.go
+++ b/gremconnect/dialer.go
@@ -59,7 +59,7 @@ type Dialer interface {
 func NewWebSocketDialer(address string) Dialer {
 	return &WebSocket{
 		timeout:      5 * time.Second,
-		pingInterval: 2 * time.Second, // TODO: revert this
+		pingInterval: 60 * time.Second,
 		writingWait:  15 * time.Second,
 		readingWait:  15 * time.Second,
 		connected:    false,

--- a/gremconnect/dialer.go
+++ b/gremconnect/dialer.go
@@ -59,7 +59,7 @@ type Dialer interface {
 func NewWebSocketDialer(address string) Dialer {
 	return &WebSocket{
 		timeout:      5 * time.Second,
-		pingInterval: 60 * time.Second,
+		pingInterval: 2 * time.Second, // TODO: revert this
 		writingWait:  15 * time.Second,
 		readingWait:  15 * time.Second,
 		connected:    false,

--- a/response.go
+++ b/response.go
@@ -73,10 +73,10 @@ func (c *Client) retrieveResponse(id string) ([][]byte, error) {
 		dataPart    []byte
 	)
 
-	// Use configured timeout if set, otherwise default to 5 seconds
+	// Use configured timeout if set, otherwise default to 60 seconds
 	timeout := c.ResponseTimeout
 	if timeout == 0 {
-		timeout = 10 * time.Second // Set default value to 10 seconds
+		timeout = 60 * time.Second // Set default value to 60 seconds
 	}
 
 	select {

--- a/response.go
+++ b/response.go
@@ -22,6 +22,8 @@ package grammes
 
 import (
 	"encoding/json"
+	"errors"
+	"time"
 
 	"github.com/Kaleidoscope-Inc/grammes/gremconnect"
 )
@@ -71,21 +73,32 @@ func (c *Client) retrieveResponse(id string) ([][]byte, error) {
 		dataPart    []byte
 	)
 
-	if n := <-notifier.(chan int); n == 1 {
-		if dataI, ok := c.results.Load(id); ok {
-			for _, d := range dataI.([]interface{}) {
-				if err, ok = d.(error); ok {
-					break
+	// Use configured timeout if set, otherwise default to 5 seconds
+	timeout := c.ResponseTimeout
+	if timeout == 0 {
+		timeout = 10 * time.Second // Set default value to 10 seconds
+	}
+
+	select {
+	case n := <-notifier.(chan int):
+		if n == 1 {
+			if dataI, ok := c.results.Load(id); ok {
+				for _, d := range dataI.([]interface{}) {
+					if err, ok = d.(error); ok {
+						break
+					}
+					if dataPart, err = jsonMarshalData(d); err != nil {
+						break
+					}
+					data = append(data, dataPart)
 				}
-				if dataPart, err = jsonMarshalData(d); err != nil {
-					break
-				}
-				data = append(data, dataPart)
+				close(notifier.(chan int))
+				c.resultMessenger.Delete(id)
+				c.deleteResponse(id)
 			}
-			close(notifier.(chan int))
-			c.resultMessenger.Delete(id)
-			c.deleteResponse(id)
 		}
+	case <-time.After(timeout):
+		return nil, errors.New("timeout waiting for Gremlin response")
 	}
 
 	return data, err

--- a/response_test.go
+++ b/response_test.go
@@ -166,7 +166,7 @@ func TestRetrieveResponse(t *testing.T) {
 
 	Convey("Given a client with a timeout set very low", t, func() {
 		c, _ := mockDial(&mockDialerStruct{})
-		c.ResponseTimeout = 1 * time.Millisecond
+		c.ResponseTimeout = 1 * time.Microsecond
 		id := "timeout-id"
 		// Prepare resultMessenger but do not send notification
 		notifier := make(chan int, 1)

--- a/response_test.go
+++ b/response_test.go
@@ -21,8 +21,10 @@
 package grammes
 
 import (
+	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	. "github.com/smartystreets/goconvey/convey"
@@ -141,6 +143,56 @@ func TestHandleResponse407Status(t *testing.T) {
 			Convey("Then no error should be returned", func() {
 				So(err, ShouldBeNil)
 			})
+		})
+	})
+}
+
+func TestRetrieveResponse(t *testing.T) {
+	Convey("Given a client with a prepared response", t, func() {
+		c, _ := mockDial(&mockDialerStruct{})
+		id := "test-id"
+		// Prepare resultMessenger and results for a successful response
+		notifier := make(chan int, 1)
+		c.resultMessenger.Store(id, notifier)
+		c.results.Store(id, []interface{}{map[string]string{"foo": "bar"}})
+		notifier <- 1
+
+		Convey("When retrieveResponse is called and data is present", func() {
+			data, err := c.retrieveResponse(id)
+			So(err, ShouldBeNil)
+			So(len(data), ShouldEqual, 1)
+		})
+	})
+
+	Convey("Given a client with a timeout set very low", t, func() {
+		c, _ := mockDial(&mockDialerStruct{})
+		c.ResponseTimeout = 1 * time.Millisecond
+		id := "timeout-id"
+		// Prepare resultMessenger but do not send notification
+		notifier := make(chan int, 1)
+		c.resultMessenger.Store(id, notifier)
+
+		Convey("When retrieveResponse is called and no data arrives in time", func() {
+			data, err := c.retrieveResponse(id)
+			So(err, ShouldNotBeNil)
+			So(data, ShouldBeNil)
+			So(err.Error(), ShouldContainSubstring, "timeout")
+		})
+	})
+
+	Convey("Given a client with an error in the data", t, func() {
+		c, _ := mockDial(&mockDialerStruct{})
+		id := "error-id"
+		notifier := make(chan int, 1)
+		c.resultMessenger.Store(id, notifier)
+		c.results.Store(id, []interface{}{errors.New("data error")})
+		notifier <- 1
+
+		Convey("When retrieveResponse is called and data contains an error", func() {
+			data, err := c.retrieveResponse(id)
+			So(err, ShouldNotBeNil)
+			So(data, ShouldBeNil)
+			So(err.Error(), ShouldContainSubstring, "data error")
 		})
 	})
 }


### PR DESCRIPTION
When graphdb connection is broken, the responseHandler keeps on waiting on notifier channel. Since no response is received, the responseHandler is blocked forever.
I have added a configurable timeout with default value of 60 seconds which breaks this deadlock.
