### PR TITLE
patch: KA-13088 added check for missing request_id

### DIFF
--- a/gremconnect/response.go
+++ b/gremconnect/response.go
@@ -61,7 +61,10 @@ func MarshalResponse(msg []byte) (Response, error) {
 	} else {
 		resp.Data = result["data"]
 	}
-	resp.RequestID = j["requestId"].(string)
+
+	if requestID, ok := j["requestId"].(string); ok {
+		resp.RequestID = requestID
+	}
 
 	return resp, nil
 }

--- a/gremconnect/response_test.go
+++ b/gremconnect/response_test.go
@@ -316,3 +316,130 @@ func TestMarshalResponseUnmarshalError(t *testing.T) {
 		})
 	})
 }
+
+func TestMarshalResponseWithMissingRequestId(t *testing.T) {
+	Convey("Given a valid response without requestId field", t, func() {
+		responseNoRequestId := `
+{
+    "status": {
+        "code": 200,
+        "attributes": {}
+    },
+    "result": {
+        "data": [{
+        }],
+        "meta": {}
+    }
+}
+`
+		byteResponse := []byte(responseNoRequestId)
+		Convey("When MarshalResponse is called", func() {
+			resp, err := MarshalResponse(byteResponse)
+			Convey("Then err should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the code should be 200", func() {
+				So(resp.Code, ShouldEqual, 200)
+			})
+			Convey("And the RequestID should be empty string", func() {
+				So(resp.RequestID, ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestMarshalResponseWithNullRequestId(t *testing.T) {
+	Convey("Given a valid response with null requestId", t, func() {
+		responseNullRequestId := `
+{
+    "requestId": null,
+    "status": {
+        "code": 200,
+        "attributes": {}
+    },
+    "result": {
+        "data": [{
+        }],
+        "meta": {}
+    }
+}
+`
+		byteResponse := []byte(responseNullRequestId)
+		Convey("When MarshalResponse is called", func() {
+			resp, err := MarshalResponse(byteResponse)
+			Convey("Then err should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the code should be 200", func() {
+				So(resp.Code, ShouldEqual, 200)
+			})
+			Convey("And the RequestID should be empty string", func() {
+				So(resp.RequestID, ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func TestMarshalResponseWithValidRequestId(t *testing.T) {
+	Convey("Given a valid response with requestId field", t, func() {
+		responseWithRequestId := `
+{
+    "requestId": "d2476e5b-b2bc-6a70-2647-3991f68ab415",
+    "status": {
+        "code": 200,
+        "attributes": {}
+    },
+    "result": {
+        "data": [{
+        }],
+        "meta": {}
+    }
+}
+`
+		byteResponse := []byte(responseWithRequestId)
+		Convey("When MarshalResponse is called", func() {
+			resp, err := MarshalResponse(byteResponse)
+			Convey("Then err should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the code should be 200", func() {
+				So(resp.Code, ShouldEqual, 200)
+			})
+			Convey("And the RequestID should be correctly populated", func() {
+				So(resp.RequestID, ShouldEqual, "d2476e5b-b2bc-6a70-2647-3991f68ab415")
+			})
+		})
+	})
+}
+
+func TestMarshalResponseErrorWithMissingRequestId(t *testing.T) {
+	Convey("Given an error response without requestId field", t, func() {
+		responseErrorNoRequestId := `
+{
+    "status": {
+        "code": 500,
+        "message": "Internal server error",
+        "attributes": {}
+    },
+    "result": {
+    }
+}
+`
+		byteResponse := []byte(responseErrorNoRequestId)
+		Convey("When MarshalResponse is called", func() {
+			resp, err := MarshalResponse(byteResponse)
+			Convey("Then err should be nil (error is in resp.Data)", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("And the code should be 500", func() {
+				So(resp.Code, ShouldEqual, 500)
+			})
+			Convey("And resp.Data should contain the network error", func() {
+				So(resp.Data, ShouldResemble, gremerror.NewNetworkError(500, "INTERNAL SERVER ERROR", "Internal server error"))
+			})
+			Convey("And the RequestID should be empty string", func() {
+				So(resp.RequestID, ShouldEqual, "")
+			})
+		})
+	})
+}


### PR DESCRIPTION

Jira Ticket: https://k6scope.atlassian.net/browse/KA-13088

The existing code performed an unsafe type assertion that would panic when requestId is null.
